### PR TITLE
feat(report): use interruptible report generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.5.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.17.7</com.diffplug.spotless.maven.plugin.version>
-    <io.cryostat.core.version>2.5.0-SNAPSHOT</io.cryostat.core.version>
+    <io.cryostat.core.version>2.5.0</io.cryostat.core.version>
     <org.jsoup.version>1.14.3</org.jsoup.version>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.5.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.17.7</com.diffplug.spotless.maven.plugin.version>
-    <io.cryostat.core.version>2.4.0</io.cryostat.core.version>
+    <io.cryostat.core.version>2.5.0-SNAPSHOT</io.cryostat.core.version>
     <org.jsoup.version>1.14.3</org.jsoup.version>
   </properties>
   <dependencyManagement>

--- a/src/main/java/io/cryostat/reports/Producers.java
+++ b/src/main/java/io/cryostat/reports/Producers.java
@@ -1,20 +1,22 @@
 package io.cryostat.reports;
 
 import java.util.Set;
+import java.util.concurrent.Executors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.Produces;
 
 import io.cryostat.core.log.Logger;
-import io.cryostat.core.reports.ReportGenerator;
+import io.cryostat.core.reports.InterruptibleReportGenerator;
 import io.cryostat.core.sys.FileSystem;
 
 public class Producers {
 
     @Produces
     @ApplicationScoped
-    ReportGenerator produceReportGenerator() {
-        return new ReportGenerator(Logger.INSTANCE, Set.of());
+    InterruptibleReportGenerator produceReportGenerator() {
+        return new InterruptibleReportGenerator(
+                Logger.INSTANCE, Set.of(), Executors.newWorkStealingPool());
     }
 
     @Produces

--- a/src/main/java/io/cryostat/reports/Producers.java
+++ b/src/main/java/io/cryostat/reports/Producers.java
@@ -1,7 +1,7 @@
 package io.cryostat.reports;
 
 import java.util.Set;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.Produces;
@@ -16,7 +16,7 @@ public class Producers {
     @ApplicationScoped
     InterruptibleReportGenerator produceReportGenerator() {
         return new InterruptibleReportGenerator(
-                Logger.INSTANCE, Set.of(), Executors.newWorkStealingPool());
+                Logger.INSTANCE, Set.of(), ForkJoinPool.commonPool());
     }
 
     @Produces


### PR DESCRIPTION
Based on top of #7 
Depends on https://github.com/cryostatio/cryostat-core/pull/108

Only the last commit in this series is unique to this PR, the rest comes from #7.

This uses the new `InterruptibleReportGenerator` in `cryostat-core` (https://github.com/cryostatio/cryostat-core/pull/108) so that the background rule-processing threads can be stopped if the request times out, or the request unexpectedly ends (network failure, client closes connection prematurely, etc). This prevents resource wastage and is particularly aimed at the "request timed out" case - if the request has already taken too long and we respond with a `504` to the client, then there is no reason at all to continue processing rules reports in the background. Without this PR, the processing will continue to completion in the background and the result simply discarded if the request has already been responded to.