### PR TITLE
build(quarkus): use Quarkus 2.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.5.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.2.5.Final</quarkus.platform.version>
+    <quarkus.plugin.version>2.2.5.Final</quarkus.plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.17.7</com.diffplug.spotless.maven.plugin.version>
     <io.cryostat.core.version>2.7.0</io.cryostat.core.version>
@@ -72,7 +73,7 @@
       <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.platform.version}</version>
+        <version>${quarkus.plugin.version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>


### PR DESCRIPTION
This also adds a separate property for the plugin version to avoid issues when using [PME](https://release-engineering.github.io/pom-manipulation-ext/).

Fixes: #17 