### PR TITLE
build(quarkus): add native-sources profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.5.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <assembly-plugin.version>3.3.0</assembly-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.17.7</com.diffplug.spotless.maven.plugin.version>
     <io.cryostat.core.version>2.7.0</io.cryostat.core.version>
     <org.jsoup.version>1.14.3</org.jsoup.version>
@@ -39,10 +40,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-reactive</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-container-image-docker</artifactId>
     </dependency>
     <dependency>
       <groupId>io.cryostat</groupId>
@@ -165,6 +162,54 @@
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
+    </profile>
+    <profile>
+      <id>native-sources</id>
+      <activation>
+        <property>
+          <name>native-sources</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native-sources</quarkus.package.type>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>${assembly-plugin.version}</version>
+            <configuration>
+              <descriptors>
+                <descriptor>src/assembly/native-sources.xml</descriptor>
+              </descriptors>
+              <tarLongFileMode>posix</tarLongFileMode>
+            </configuration>
+            <executions>
+              <execution>
+                <id>assemble-native-sources</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>container-build</id>
+      <activation>
+        <property>
+          <name>!native-sources</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-container-image-docker</artifactId>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>

--- a/src/assembly/native-sources.xml
+++ b/src/assembly/native-sources.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>native-sources</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <outputDirectory />
+      <directory>${project.build.directory}/native-sources</directory>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
Adds a profile to build with the native-sources packaging type. The resulting native-sources directory is assembled into a tarball. This also makes the `quarkus-container-image-docker` extension used only when not doing a native-sources build, as it will fail. Building is done with `mvn -Dnative-sources <goals>`.

Fixes: #16 

Depends on: #4 