### PR TITLE
build(quarkus): revert plugin version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.2.5.Final</quarkus.platform.version>
-    <quarkus.plugin.version>2.2.5.Final</quarkus.plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.17.7</com.diffplug.spotless.maven.plugin.version>
     <io.cryostat.core.version>2.9.0</io.cryostat.core.version>
@@ -73,7 +72,7 @@
       <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.plugin.version}</version>
+        <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>


### PR DESCRIPTION
It turns out this property is causing more harm than good. I'd like to revert this change.

Related to: #19 