### PR TITLE
feat(reports): API requests can specify filtered rules and topics for evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The application can be packaged using:
 ```shell script
 ./mvnw package
 ```
+
 It produces the `quarkus-run.jar` file in the `target/quarkus-app/` directory.
 Be aware that it’s not an _über-jar_ as the dependencies are copied into the `target/quarkus-app/lib/` directory.
 
@@ -34,6 +35,11 @@ The application is now runnable using `java -jar target/quarkus-app/quarkus-run.
 
 An OCI image tagged as `quay.io/cryostatio/cryostat-reports` will also be built using `podman`
 and loaded into your local `podman` image registry.
+
+If a Quarkus build failure is encountered due to being unable to build a Docker image, then:
+```shell script
+sudo install podman-docker
+```
 
 ## Creating a native executable
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
       <artifactId>cryostat-core</artifactId>
       <version>${io.cryostat.core.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -65,12 +70,6 @@
       <artifactId>jsoup</artifactId>
       <version>${org.jsoup.version}</version>
       <scope>test</scope>
-    </dependency>
-  
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.2.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.17.7</com.diffplug.spotless.maven.plugin.version>
-    <io.cryostat.core.version>2.11.0-SNAPSHOT</io.cryostat.core.version>
+    <io.cryostat.core.version>2.10.0</io.cryostat.core.version>
     <org.jsoup.version>1.14.3</org.jsoup.version>
   </properties>
   <dependencyManagement>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.9</version>
+      <version>3.12.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.2.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.17.7</com.diffplug.spotless.maven.plugin.version>
-    <io.cryostat.core.version>2.9.1</io.cryostat.core.version>
+    <io.cryostat.core.version>2.11.0-SNAPSHOT</io.cryostat.core.version>
     <org.jsoup.version>1.14.3</org.jsoup.version>
   </properties>
   <dependencyManagement>
@@ -65,6 +65,12 @@
       <artifactId>jsoup</artifactId>
       <version>${org.jsoup.version}</version>
       <scope>test</scope>
+    </dependency>
+  
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.9</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/io/cryostat/reports/RecordingFormData.java
+++ b/src/main/java/io/cryostat/reports/RecordingFormData.java
@@ -2,8 +2,6 @@ package io.cryostat.reports;
 
 import javax.ws.rs.core.MediaType;
 
-import java.util.Optional;
-
 import org.jboss.resteasy.reactive.PartType;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.multipart.FileUpload;

--- a/src/main/java/io/cryostat/reports/RecordingFormData.java
+++ b/src/main/java/io/cryostat/reports/RecordingFormData.java
@@ -2,6 +2,8 @@ package io.cryostat.reports;
 
 import javax.ws.rs.core.MediaType;
 
+import java.util.Optional;
+
 import org.jboss.resteasy.reactive.PartType;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
@@ -10,4 +12,8 @@ public class RecordingFormData {
     @RestForm
     @PartType(MediaType.APPLICATION_OCTET_STREAM)
     public FileUpload file;
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public String filter;
 }

--- a/src/test/java/io/cryostat/ReportResourceTest.java
+++ b/src/test/java/io/cryostat/ReportResourceTest.java
@@ -56,4 +56,82 @@ public class ReportResourceTest {
                 titles.get(0).html(), Matchers.equalTo("Automated Analysis Result Overview"));
         MatcherAssert.assertThat("Expected one <body>", body.size(), Matchers.equalTo(1));
     }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "/profiling_sample.jfr",
+                "/profiling_sample.jfr.gz",
+            })
+    public void testReportEndpointWithFilters(String filePath) throws URISyntaxException {
+        File jfr = Paths.get(getClass().getResource(filePath).toURI()).toFile();
+        String response =
+                given().contentType("multipart/form-data")
+                        .multiPart("file", jfr)
+                        .formParam("filter", "LongGcPause,heap")
+                        .when()
+                        .post("/report")
+                        .then()
+                        .statusCode(200)
+                        .contentType("text/html")
+                        .body(Matchers.is(Matchers.not(Matchers.emptyOrNullString())))
+                        .extract()
+                        .asString();
+
+        Document doc = Jsoup.parse(response, "UTF-8");
+
+        Elements head = doc.getElementsByTag("head");
+        Elements titles = head.first().getElementsByTag("title");
+        Elements body = doc.getElementsByTag("body");
+        Elements rules = doc.select("div.rule");
+        Elements specificRule = doc.getElementsByAttributeValueMatching("name", "LongGcPause");
+
+        MatcherAssert.assertThat("Expected one <head>", head.size(), Matchers.equalTo(1));
+        MatcherAssert.assertThat("Expected one <title>", titles.size(), Matchers.equalTo(1));
+        MatcherAssert.assertThat(
+                titles.get(0).html(), Matchers.equalTo("Automated Analysis Result Overview"));
+        MatcherAssert.assertThat("Expected one <body>", body.size(), Matchers.equalTo(1));
+        MatcherAssert.assertThat(
+                "Expect 7 heap rules, and 1 LongGcPause rule", rules.size(), Matchers.equalTo(8));
+        MatcherAssert.assertThat(
+                "Expect LongGcPause rule to be present",
+                specificRule.attr("name"),
+                Matchers.equalTo("LongGcPause"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "/profiling_sample.jfr",
+                "/profiling_sample.jfr.gz",
+            })
+    public void testReportEndpointWithInvalidFilters(String filePath) throws URISyntaxException {
+        File jfr = Paths.get(getClass().getResource(filePath).toURI()).toFile();
+        String response =
+                given().contentType("multipart/form-data")
+                        .multiPart("file", jfr)
+                        .formParam("filter", "FakeRule")
+                        .when()
+                        .post("/report")
+                        .then()
+                        .statusCode(200)
+                        .contentType("text/html")
+                        .body(Matchers.is(Matchers.not(Matchers.emptyOrNullString())))
+                        .extract()
+                        .asString();
+
+        Document doc = Jsoup.parse(response, "UTF-8");
+
+        Elements head = doc.getElementsByTag("head");
+        Elements titles = head.first().getElementsByTag("title");
+        Elements body = doc.getElementsByTag("body");
+        Elements rules = doc.select("div.rule");
+
+        MatcherAssert.assertThat("Expected one <head>", head.size(), Matchers.equalTo(1));
+        MatcherAssert.assertThat("Expected one <title>", titles.size(), Matchers.equalTo(1));
+        MatcherAssert.assertThat(
+                titles.get(0).html(), Matchers.equalTo("Automated Analysis Result Overview"));
+        MatcherAssert.assertThat("Expected one <body>", body.size(), Matchers.equalTo(1));
+        MatcherAssert.assertThat("Expect no rules", rules.size(), Matchers.equalTo(0));
+    }
 }


### PR DESCRIPTION
Related to #28 

Right now, send a request to /report with filters you do (using curl)

`curl -v -F file=@foo.jfr -F filter=HighGc,DumpReason,memoryleak localhost:8080/report`

where HighGc and DumpReason are rules, and memoryleak is a topic (a topic with one rule in it)

Thoughts?
