### PR TITLE
feat(reports): added jsonability to /report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,6 @@
       <artifactId>cryostat-core</artifactId>
       <version>${io.cryostat.core.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
-    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.22.7</com.diffplug.spotless.maven.plugin.version>
     <org.codehaus.mojo.build.helper.plugin.version>3.3.0</org.codehaus.mojo.build.helper.plugin.version>
-<<<<<<< HEAD
     <io.cryostat.core.version>2.12.0</io.cryostat.core.version>
-=======
-    <io.cryostat.core.version>2.12.0-SNAPSHOT</io.cryostat.core.version>
->>>>>>> 2bff7a3 (added jsonability to /report)
     <org.jsoup.version>1.14.3</org.jsoup.version>
   </properties>
   <dependencyManagement>
@@ -60,9 +56,8 @@
       <version>3.12.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.5</version>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,11 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.22.7</com.diffplug.spotless.maven.plugin.version>
     <org.codehaus.mojo.build.helper.plugin.version>3.3.0</org.codehaus.mojo.build.helper.plugin.version>
+<<<<<<< HEAD
     <io.cryostat.core.version>2.12.0</io.cryostat.core.version>
+=======
+    <io.cryostat.core.version>2.12.0-SNAPSHOT</io.cryostat.core.version>
+>>>>>>> 2bff7a3 (added jsonability to /report)
     <org.jsoup.version>1.14.3</org.jsoup.version>
   </properties>
   <dependencyManagement>
@@ -54,6 +58,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
+      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -54,10 +54,6 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-jackson</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/cryostat/reports/RecordingFormData.java
+++ b/src/main/java/io/cryostat/reports/RecordingFormData.java
@@ -14,8 +14,4 @@ public class RecordingFormData {
     @RestForm
     @PartType(MediaType.TEXT_PLAIN)
     public String filter;
-
-    @RestForm
-    @PartType(MediaType.TEXT_PLAIN)
-    public String eval;
 }

--- a/src/main/java/io/cryostat/reports/RecordingFormData.java
+++ b/src/main/java/io/cryostat/reports/RecordingFormData.java
@@ -14,4 +14,8 @@ public class RecordingFormData {
     @RestForm
     @PartType(MediaType.TEXT_PLAIN)
     public String filter;
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public String eval;
 }

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -58,7 +58,7 @@ public class ReportResource {
     @Inject Logger logger;
     @Inject InterruptibleReportGenerator generator;
     @Inject FileSystem fs;
-    
+
     RuleFilterParser rfp = new RuleFilterParser();
 
     void onStart(@Observes StartupEvent ev) {

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -31,10 +31,13 @@ import io.cryostat.core.reports.InterruptibleReportGenerator.ReportResult;
 import io.cryostat.core.reports.InterruptibleReportGenerator.RuleEvaluation;
 import io.cryostat.core.sys.FileSystem;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.common.annotation.Blocking;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.MultipartForm;
@@ -42,8 +45,6 @@ import org.jboss.resteasy.reactive.multipart.FileUpload;
 import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.flightrecorder.rules.IRule;
 import org.openjdk.jmc.flightrecorder.rules.RuleRegistry;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Path("/")
 public class ReportResource {
@@ -88,203 +89,116 @@ public class ReportResource {
     @Path("report")
     @Produces(MediaType.TEXT_HTML)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public class Report {
-        @POST
-        public String getReport(RoutingContext ctx, @MultipartForm RecordingFormData form)
+    @POST
+    public String getReport(RoutingContext ctx, @MultipartForm RecordingFormData form)
             throws IOException {
-            FileUpload upload = form.file;
-            String filter = form.filter;
-            Predicate<IRule> predicate = getPredicateRuleFilter(filter);
+        FileUpload upload = form.file;
 
-            java.nio.file.Path file = upload.uploadedFile();
-            long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
-            long start = System.nanoTime();
-            long now = start;
-            long elapsed = 0;
-            ReportGenerationEvent evt = new ReportGenerationEvent(upload.fileName());
+        Triple<java.nio.file.Path, ReportGenerationEvent, Pair<Long, Long>> tripleHelper =
+                reportHelper(upload);
+        java.nio.file.Path file = tripleHelper.getLeft();
+        ReportGenerationEvent evt = tripleHelper.getMiddle();
+        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
+        long start = tripleHelper.getRight().getLeft();
+        long elapsed = tripleHelper.getRight().getRight();
 
-            logger.infof("Received request for %s (%d bytes)", upload.fileName(), upload.size());
-            evt.begin();
+        Predicate<IRule> predicate = getPredicateRuleFilter(form.filter);
+        Future<ReportResult> reportFuture = null;
 
-            if (IOToolkit.isCompressedFile(file.toFile())) {
-                file = decompress(file);
-                now = System.nanoTime();
-                elapsed = now - start;
-                logger.infof(
-                        "%s was compressed. Decompressed size: %d bytes. Decompression took %dms",
-                        upload.fileName(),
-                        file.toFile().length(),
-                        TimeUnit.NANOSECONDS.toMillis(elapsed));
-            }
-
-            Runtime runtime = Runtime.getRuntime();
-            System.gc();
-            long availableMemory = runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory();
-            long maxHandleableSize = availableMemory / Long.parseLong(memoryFactor);
-            if (file.toFile().length() > maxHandleableSize) {
-                throw new ClientErrorException(Response.Status.REQUEST_ENTITY_TOO_LARGE);
-            }
-
-            now = System.nanoTime();
-            elapsed = now - start;
-            if (elapsed > timeout) {
-                throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT);
-            }
-
-            Future<ReportResult> reportFuture = null;
-
-            try (var stream = fs.newInputStream(file)) {
-                reportFuture = generator.generateReportInterruptibly(stream, predicate);
-                ctxHelper(ctx, reportFuture);
-                evt.setRecordingSizeBytes(
-                            reportFuture.get().getReportStats().getRecordingSizeBytes());
-                evt.setRulesEvaluated(reportFuture.get().getReportStats().getRulesEvaluated());
-                evt.setRulesApplicable(reportFuture.get().getReportStats().getRulesApplicable());
-                return reportFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS).getHtml();
-            } catch (ExecutionException | InterruptedException e) {
-                throw new InternalServerErrorException(e);
-            } catch (TimeoutException e) {
-                throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
-            } finally {
-                if (reportFuture != null) {
-                    reportFuture.cancel(true);
-                }
-                boolean deleted = fs.deleteIfExists(file);
-                if (deleted) {
-                    logger.infof("Deleted %s", file);
-                } else {
-                    logger.infof("Failed to delete %s", file);
-                }
-                logger.infof(
-                        "Completed request for %s after %dms",
-                        upload.fileName(), TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
-                evt.end();
-                if (evt.shouldCommit()) {
-                    evt.commit();
-                }
-            }
+        try (var stream = fs.newInputStream(file)) {
+            reportFuture = generator.generateReportInterruptibly(stream, predicate);
+            ctxHelper(ctx, reportFuture);
+            evt.setRecordingSizeBytes(reportFuture.get().getReportStats().getRecordingSizeBytes());
+            evt.setRulesEvaluated(reportFuture.get().getReportStats().getRulesEvaluated());
+            evt.setRulesApplicable(reportFuture.get().getReportStats().getRulesApplicable());
+            return reportFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS).getHtml();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new InternalServerErrorException(e);
+        } catch (TimeoutException e) {
+            throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
+        } finally {
+            cleanupHelper(reportFuture, file, evt, upload.fileName(), start);
         }
-        @POST 
-        @Produces(MediaType.APPLICATION_JSON)
-        public String getEval(RoutingContext ctx, @MultipartForm RecordingFormData form) throws IOException {
-                        FileUpload upload = form.file;
-            String filter = form.filter;
-
-            java.nio.file.Path file = upload.uploadedFile();
-            long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
-            long start = System.nanoTime();
-            long now = start;
-            long elapsed = 0;
-            ReportGenerationEvent evt = new ReportGenerationEvent(upload.fileName());
-
-            logger.infof("Received request for %s (%d bytes)", upload.fileName(), upload.size());
-            evt.begin();
-
-            if (IOToolkit.isCompressedFile(file.toFile())) {
-                file = decompress(file);
-                now = System.nanoTime();
-                elapsed = now - start;
-                logger.infof(
-                        "%s was compressed. Decompressed size: %d bytes. Decompression took %dms",
-                        upload.fileName(),
-                        file.toFile().length(),
-                        TimeUnit.NANOSECONDS.toMillis(elapsed));
-            }
-
-            Runtime runtime = Runtime.getRuntime();
-            System.gc();
-            long availableMemory = runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory();
-            long maxHandleableSize = availableMemory / Long.parseLong(memoryFactor);
-            if (file.toFile().length() > maxHandleableSize) {
-                throw new ClientErrorException(Response.Status.REQUEST_ENTITY_TOO_LARGE);
-            }
-
-            now = System.nanoTime();
-            elapsed = now - start;
-            if (elapsed > timeout) {
-                throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT);
-            }
-
-            Predicate<IRule> predicate = getPredicateRuleFilter(filter);
-            Future<Map<String, RuleEvaluation>> evalMapFuture = null;
-
-            try (var stream = fs.newInputStream(file)) {
-                    ObjectMapper oMapper = new ObjectMapper();
-                    evalMapFuture = generator.generateEvalMapInterruptibly(stream, predicate);
-                    ctxHelper(ctx, evalMapFuture);
-                    // TODO: Add some sort of ReportStats for EvalMap/RuleEvaluation
-                    evt.setRecordingSizeBytes(0);
-                    evt.setRulesEvaluated(0);
-                    evt.setRulesApplicable(0);
-                    return oMapper.writeValueAsString(evalMapFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));
-            } catch (ExecutionException | InterruptedException e) {
-                throw new InternalServerErrorException(e);
-            } catch (TimeoutException e) {
-                throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
-            } finally {
-                if (evalMapFuture != null) {
-                    evalMapFuture.cancel(true);
-                }
-                boolean deleted = fs.deleteIfExists(file);
-                if (deleted) {
-                    logger.infof("Deleted %s", file);
-                } else {
-                    logger.infof("Failed to delete %s", file);
-                }
-                logger.infof(
-                        "Completed request for %s after %dms",
-                        upload.fileName(), TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
-                evt.end();
-                if (evt.shouldCommit()) {
-                    evt.commit();
-                }
-            }
-        }
-
-    //     private List<Object> reportHelper(RoutingContext ctx, @MultipartForm RecordingFormData form) throws IOException {
-    //         FileUpload upload = form.file;
-    //         java.nio.file.Path file = upload.uploadedFile();
-    //         long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
-    //         long start = System.nanoTime();
-    //         long now = start;
-    //         long elapsed = 0;
-    //         ReportGenerationEvent evt = new ReportGenerationEvent(upload.fileName());
-
-    //         logger.infof("Received request for %s (%d bytes)", upload.fileName(), upload.size());
-    //         evt.begin();
-
-    //         if (IOToolkit.isCompressedFile(file.toFile())) {
-    //             file = decompress(file);
-    //             now = System.nanoTime();
-    //             elapsed = now - start;
-    //             logger.infof(
-    //                     "%s was compressed. Decompressed size: %d bytes. Decompression took %dms",
-    //                     upload.fileName(),
-    //                     file.toFile().length(),
-    //                     TimeUnit.NANOSECONDS.toMillis(elapsed));
-    //         }
-
-    //         Runtime runtime = Runtime.getRuntime();
-    //         System.gc();
-    //         long availableMemory = runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory();
-    //         long maxHandleableSize = availableMemory / Long.parseLong(memoryFactor);
-    //         if (file.toFile().length() > maxHandleableSize) {
-    //             throw new ClientErrorException(Response.Status.REQUEST_ENTITY_TOO_LARGE);
-    //         }
-
-    //         now = System.nanoTime();
-    //         elapsed = now - start;
-    //         if (elapsed > timeout) {
-    //             throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT);
-    //         }
-
-    //         Predicate<IRule> predicate = getPredicateRuleFilter(form.filter);
-    //         return List.of(file, evt, timeout, elapsed, predicate);
-    //     }
-
-    // }
     }
-    
+
+    @Blocking
+    @Path("report")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @POST
+    public String getEval(RoutingContext ctx, @MultipartForm RecordingFormData form)
+            throws IOException {
+        FileUpload upload = form.file;
+
+        Triple<java.nio.file.Path, ReportGenerationEvent, Pair<Long, Long>> tripleHelper =
+                reportHelper(upload);
+        java.nio.file.Path file = tripleHelper.getLeft();
+        ReportGenerationEvent evt = tripleHelper.getMiddle();
+        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
+        long start = tripleHelper.getRight().getLeft();
+        long elapsed = tripleHelper.getRight().getRight();
+
+        Predicate<IRule> predicate = getPredicateRuleFilter(form.filter);
+        Future<Map<String, RuleEvaluation>> evalMapFuture = null;
+
+        ObjectMapper oMapper = new ObjectMapper();
+        try (var stream = fs.newInputStream(file)) {
+            evalMapFuture = generator.generateEvalMapInterruptibly(stream, predicate);
+            ctxHelper(ctx, evalMapFuture);
+            // TODO: Add some sort of ReportStats for EvalMap/RuleEvaluation
+            evt.setRecordingSizeBytes(0);
+            evt.setRulesEvaluated(0);
+            evt.setRulesApplicable(0);
+            return oMapper.writeValueAsString(
+                    evalMapFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));
+        } catch (ExecutionException | InterruptedException e) {
+            throw new InternalServerErrorException(e);
+        } catch (TimeoutException e) {
+            throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
+        } finally {
+            cleanupHelper(evalMapFuture, file, evt, upload.fileName(), start);
+        }
+    }
+
+    private Triple<java.nio.file.Path, ReportGenerationEvent, Pair<Long, Long>> reportHelper(
+            FileUpload upload) throws IOException {
+        java.nio.file.Path file = upload.uploadedFile();
+        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
+        long start = System.nanoTime();
+        long now = start;
+        long elapsed = 0;
+        ReportGenerationEvent evt = new ReportGenerationEvent(upload.fileName());
+
+        logger.infof("Received request for %s (%d bytes)", upload.fileName(), upload.size());
+        evt.begin();
+
+        if (IOToolkit.isCompressedFile(file.toFile())) {
+            file = decompress(file);
+            now = System.nanoTime();
+            elapsed = now - start;
+            logger.infof(
+                    "%s was compressed. Decompressed size: %d bytes. Decompression took %dms",
+                    upload.fileName(),
+                    file.toFile().length(),
+                    TimeUnit.NANOSECONDS.toMillis(elapsed));
+        }
+
+        Runtime runtime = Runtime.getRuntime();
+        System.gc();
+        long availableMemory = runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory();
+        long maxHandleableSize = availableMemory / Long.parseLong(memoryFactor);
+        if (file.toFile().length() > maxHandleableSize) {
+            throw new ClientErrorException(Response.Status.REQUEST_ENTITY_TOO_LARGE);
+        }
+
+        now = System.nanoTime();
+        elapsed = now - start;
+        if (elapsed > timeout) {
+            throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT);
+        }
+        return Triple.of(file, evt, Pair.of(start, elapsed));
+    }
+
     private void ctxHelper(RoutingContext ctx, Future<?> ff) {
         ctx.response()
                 .exceptionHandler(
@@ -299,6 +213,31 @@ public class ReportResource {
                             ff.cancel(true);
                         });
         ctx.addEndHandler().onComplete(ar -> ff.cancel(true));
+    }
+
+    private void cleanupHelper(
+            Future<?> future,
+            java.nio.file.Path file,
+            ReportGenerationEvent evt,
+            String fileName,
+            long start)
+            throws IOException {
+        if (future != null) {
+            future.cancel(true);
+        }
+        boolean deleted = fs.deleteIfExists(file);
+        if (deleted) {
+            logger.infof("Deleted %s", file);
+        } else {
+            logger.infof("Failed to delete %s", file);
+        }
+        logger.infof(
+                "Completed request for %s after %dms",
+                fileName, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
+        evt.end();
+        if (evt.shouldCommit()) {
+            evt.commit();
+        }
     }
 
     // TODO: Refactor this as a util function into cryostat-core

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -9,7 +9,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -157,10 +156,10 @@ public class ReportResource {
         // TODO: Add some sort of ReportStats for EvalMap/RuleEvaluation (setRecordingSizeBytes)
         int rulesEvaluated = evalMap.size();
         int rulesApplicable =
-                evalMap.values().stream()
-                        .filter(result -> result.getScore() != Result.NOT_APPLICABLE)
-                        .collect(Collectors.toList())
-                        .size();
+                (int)
+                        evalMap.values().stream()
+                                .filter(result -> result.getScore() != Result.NOT_APPLICABLE)
+                                .count();
 
         return Triple.of(Long.valueOf(0), rulesEvaluated, rulesApplicable);
     }

--- a/src/test/java/io/cryostat/ReportResourceTest.java
+++ b/src/test/java/io/cryostat/ReportResourceTest.java
@@ -5,8 +5,15 @@ import static io.restassured.RestAssured.given;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
+import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jsoup.Jsoup;
@@ -15,6 +22,7 @@ import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openjdk.jmc.flightrecorder.rules.RuleRegistry;
 
 @QuarkusTest
 public class ReportResourceTest {
@@ -133,5 +141,79 @@ public class ReportResourceTest {
                 titles.get(0).html(), Matchers.equalTo("Automated Analysis Result Overview"));
         MatcherAssert.assertThat("Expected one <body>", body.size(), Matchers.equalTo(1));
         MatcherAssert.assertThat("Expect no rules", rules.size(), Matchers.equalTo(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "/profiling_sample.jfr",
+                "/profiling_sample.jfr.gz",
+            })
+    public void testReportEndpointForJSON(String filePath)
+            throws URISyntaxException, JsonMappingException, JsonProcessingException {
+        File jfr = Paths.get(getClass().getResource(filePath).toURI()).toFile();
+        String response =
+                given().contentType("multipart/form-data")
+                        .accept(ContentType.JSON)
+                        .multiPart("file", jfr)
+                        .when()
+                        .post("/report")
+                        .then()
+                        .statusCode(200)
+                        .contentType("application/json")
+                        .body(Matchers.is(Matchers.not(Matchers.emptyOrNullString())))
+                        .extract()
+                        .asString();
+
+        ObjectMapper oMapper = new ObjectMapper();
+        Map<String, RuleEvaluation> map =
+                oMapper.readValue(response, new TypeReference<Map<String, RuleEvaluation>>() {});
+        int numRules = RuleRegistry.getRules().size();
+
+        MatcherAssert.assertThat(map, Matchers.notNullValue());
+        MatcherAssert.assertThat(
+                String.format("Expect {%d} rules", numRules),
+                map.size(),
+                Matchers.equalTo(numRules));
+        for (var e : map.entrySet()) {
+            MatcherAssert.assertThat(e, Matchers.notNullValue());
+            MatcherAssert.assertThat(e.getValue(), Matchers.notNullValue());
+            MatcherAssert.assertThat(
+                    e.getValue().getDescription(), Matchers.not(Matchers.emptyOrNullString()));
+            MatcherAssert.assertThat(
+                    e.getValue().getName(), Matchers.not(Matchers.emptyOrNullString()));
+            MatcherAssert.assertThat(
+                    e.getValue().getTopic(), Matchers.not(Matchers.emptyOrNullString()));
+            MatcherAssert.assertThat(e.getValue().getScore(), Matchers.not(Matchers.notANumber()));
+        }
+    }
+
+    private static class RuleEvaluation {
+        private double score;
+        private String name;
+        private String topic;
+        private String description;
+
+        private RuleEvaluation() {}
+
+        @JsonProperty("score")
+        public double getScore() {
+            return score;
+        }
+
+        @JsonProperty("name")
+        public String getName() {
+            return name;
+        }
+
+        @JsonProperty("topic")
+        public String getTopic() {
+            return topic;
+        }
+
+        @JsonProperty("description")
+        public String getDescription() {
+            return description;
+        }
     }
 }

--- a/src/test/java/io/cryostat/ReportResourceTest.java
+++ b/src/test/java/io/cryostat/ReportResourceTest.java
@@ -171,10 +171,7 @@ public class ReportResourceTest {
         int numRules = RuleRegistry.getRules().size();
 
         MatcherAssert.assertThat(map, Matchers.notNullValue());
-        MatcherAssert.assertThat(
-                String.format("Expect {%d} rules", numRules),
-                map.size(),
-                Matchers.equalTo(numRules));
+        MatcherAssert.assertThat(map, Matchers.aMapWithSize(numRules));
         for (var e : map.entrySet()) {
             MatcherAssert.assertThat(e, Matchers.notNullValue());
             MatcherAssert.assertThat(e.getValue(), Matchers.notNullValue());
@@ -184,7 +181,14 @@ public class ReportResourceTest {
                     e.getValue().getName(), Matchers.not(Matchers.emptyOrNullString()));
             MatcherAssert.assertThat(
                     e.getValue().getTopic(), Matchers.not(Matchers.emptyOrNullString()));
-            MatcherAssert.assertThat(e.getValue().getScore(), Matchers.not(Matchers.notANumber()));
+            MatcherAssert.assertThat(
+                    e.getValue().getScore(),
+                    Matchers.anyOf(
+                            Matchers.equalTo(-1d),
+                            Matchers.equalTo(-2d),
+                            Matchers.equalTo(-3d),
+                            Matchers.both(Matchers.lessThanOrEqualTo(100d))
+                                    .and(Matchers.greaterThanOrEqualTo(0d))));
         }
     }
 


### PR DESCRIPTION
Fixes #23 
Depends on #42

Works by
curl -v -F file=@foo.jfr -F filter=heap -F eval="anything" localhost:8080/report

The form parameter "eval" can be anything, and it will spit out JSON as a String. If its not provided, then /report works normally.

Thoughts before tests and etc.?