### PR TITLE
chore(docs): add missing dnf command and additional notes on docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cryostat-reports Project
+# cryostat-reports
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ and loaded into your local `podman` image registry.
 
 If a Quarkus build failure is encountered due to being unable to build a Docker image, then:
 ```shell script
-sudo install podman-docker
+sudo dnf install podman-docker
 ```
+
+**Note**: If `docker` is already installed, then starting `docker` will solve the issue.
 
 ## Creating a native executable
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If a Quarkus build failure is encountered due to being unable to build a Docker 
 sudo dnf install podman-docker
 ```
 
-**Note**: If `docker` is already installed, then starting `docker` will solve the issue.
+**Note**: If `docker` is already installed, then starting the `docker` service will solve the issue.
 
 ## Creating a native executable
 


### PR DESCRIPTION
Fixes #43 

Add missing `dnf` command and additional notes for cases with installed docker.