### PR TITLE
build(core): use -core 2.16.2 from GH pkgs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,6 @@ jobs:
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore
-    - uses: actions/download-artifact@v2
-      with:
-        name: cryostat-core
-        path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
     - run: mvn -B -U clean verify
       env:
         GITHUB_TOKEN_REF: ${{ secrets.GH_PKGS_READ_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,49 +15,9 @@ on:
       - cryostat-v[0-9]+.[0-9]+
 
 jobs:
-  get-pom-properties:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - id: query-pom
-      name: Get properties from POM
-      # Query POM for core and image version and save as output parameter
-      run: |
-        CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
-        echo "::set-output name=core-version::v$CORE_VERSION"
-        IMAGE_VERSION="$(mvn validate help:evaluate -Dexpression=quarkus.container-image.tag -q -DforceStdout)"
-        echo "::set-output name=image-version::$IMAGE_VERSION"
-    outputs:
-      core-version: ${{ steps.query-pom.outputs.core-version }}
-      image-version: ${{ steps.query-pom.outputs.image-version }}
-
-  build-deps:
-    runs-on: ubuntu-latest
-    needs: [get-pom-properties]
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        repository: cryostatio/cryostat-core
-        ref: ${{ needs.get-pom-properties.outputs.core-version }}
-    - uses: actions/setup-java@v2
-      with:
-        java-version: '17'
-        distribution: 'adopt'
-    - uses: skjolber/maven-cache-github-action@v1
-      with:
-        step: restore
-    - run: mvn -B -U -DskipTests=true clean install
-    - uses: actions/upload-artifact@v2
-      with:
-        name: cryostat-core
-        path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
-    - uses: skjolber/maven-cache-github-action@v1
-      with:
-        step: save
 
   build:
     runs-on: ubuntu-latest
-    needs: [get-pom-properties, build-deps]
     env:
       CRYOSTAT_REPORTS_IMG: quay.io/cryostat/cryostat-reports
     steps:
@@ -68,6 +28,11 @@ jobs:
       with:
         java-version: '17'
         distribution: 'adopt'
+    - name: maven-settings
+      uses: s4u/maven-settings-action@v2
+      with:
+        servers: '[{"id": "github", "username": "dummy", "password": "${env.GITHUB_TOKEN_REF}"}]'
+        githubServer: false
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore
@@ -76,6 +41,8 @@ jobs:
         name: cryostat-core
         path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
     - run: mvn -B -U clean verify
+      env:
+        GITHUB_TOKEN_REF: ${{ secrets.GH_PKGS_READ_TOKEN }}
     - name: Tag images
       id: tag-image
       env:

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,12 @@
   <groupId>io.cryostat</groupId>
   <artifactId>cryostat-reports</artifactId>
   <version>2.3.0-SNAPSHOT</version>
+  <repositories>
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/cryostatio/cryostat-core</url>
+    </repository>
+  </repositories>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -18,7 +24,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.22.7</com.diffplug.spotless.maven.plugin.version>
     <org.codehaus.mojo.build.helper.plugin.version>3.3.0</org.codehaus.mojo.build.helper.plugin.version>
-    <io.cryostat.core.version>2.14.1</io.cryostat.core.version>
+    <io.cryostat.core.version>2.16.2</io.cryostat.core.version>
     <org.jsoup.version>1.15.3</org.jsoup.version>
     <com.mycila.license.maven.plugin.version>4.0</com.mycila.license.maven.plugin.version>
   </properties>


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat-core/issues/92
See also https://github.com/cryostatio/cryostat-agent/pull/18

Simply replaces the CI's inlined -core build with configuration to download -core from the GitHub Packages repository where -core's own CI builds (on each released version) are published.