### PR TITLE
ci(deps): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "cryostatio/reviewers"
+    labels:
+      - "dependencies"
+      - "chore"
+      - "safe-to-test"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "docker"
+    directory: "/src/main/docker"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "cryostatio/reviewers"
+    labels:
+      - "dependencies"
+      - "chore"
+      - "safe-to-test"


### PR DESCRIPTION
This config is identical to [Cryostat's](https://github.com/cryostatio/cryostat/blob/57bed8e7e14a9b40be1e1b021a67796b87482181/.github/dependabot.yml), with only the container path changed to the location of the Dockerfiles in this repo.

Fixes: #56 