### PR TITLE
ci(deps): configure Dependabot to read from GH packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ registries:
   maven-github:
     type: maven-repository
     url: https://maven.pkg.github.com/cryostatio/cryostat-core
-    token: ${{secrets.DEPENDABOT_READ_GHCR}}
+    username: dummy
+    password: ${{secrets.DEPENDABOT_READ_GHCR}}
 updates:
   - package-ecosystem: "maven"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,9 @@
 version: 2
+registries:
+  maven-github:
+    type: maven-repository
+    url: https://maven.pkg.github.com/cryostatio/cryostat-core
+    token: ${{secrets.DEPENDABOT_READ_GHCR}}
 updates:
   - package-ecosystem: "maven"
     directory: "/"
@@ -11,6 +16,8 @@ updates:
       - "chore"
       - "safe-to-test"
     open-pull-requests-limit: 10
+    registries:
+      - "maven-github"
 
   - package-ecosystem: "docker"
     directory: "/src/main/docker"


### PR DESCRIPTION
I'm trying to get Dependabot to update cryostat-core. I followed this documentation: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot

Related to: #56 