### PR TITLE
feat(s3): add endpoint for requesting report generation from presigned S3 URL

### DIFF
--- a/src/main/java/io/cryostat/reports/PresignedFormData.java
+++ b/src/main/java/io/cryostat/reports/PresignedFormData.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.reports;
+
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+
+public class PresignedFormData {
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public String path;
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public String query;
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public String filter;
+}

--- a/src/main/java/io/cryostat/reports/Producers.java
+++ b/src/main/java/io/cryostat/reports/Producers.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 
 import io.cryostat.core.reports.InterruptibleReportGenerator;
+import io.cryostat.core.util.RuleFilterParser;
 import io.cryostat.libcryostat.sys.FileSystem;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -37,6 +38,12 @@ public class Producers {
                         || Boolean.getBoolean(ReportResource.SINGLETHREAD_PROPERTY);
         return new InterruptibleReportGenerator(
                 singleThread ? Executors.newSingleThreadExecutor() : ForkJoinPool.commonPool());
+    }
+
+    @Produces
+    @ApplicationScoped
+    RuleFilterParser produceRuleFilterParser() {
+        return new RuleFilterParser();
     }
 
     @Produces

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -111,6 +111,10 @@ public class ReportResource {
         long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
         long start = System.nanoTime();
 
+        if (storageBase.isEmpty()) {
+            throw new ServerErrorException(Response.Status.BAD_GATEWAY);
+        }
+
         UriBuilder uriBuilder =
                 UriBuilder.newInstance()
                         .uri(new URI(storageBase.get()))

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -83,9 +83,8 @@ public class ReportResource {
     @Inject InterruptibleReportGenerator generator;
     @Inject FileSystem fs;
     @Inject ObjectMapper mapper;
+    @Inject RuleFilterParser rfp;
     @Inject Logger logger;
-
-    RuleFilterParser rfp = new RuleFilterParser();
 
     void onStart(@Observes StartupEvent ev) {
         logger.infof(

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -110,7 +110,9 @@ public class ReportResource {
             throws IOException, URISyntaxException {
         // TODO queue these requests so we don't overload ourselves, in particular by reading
         // multiple JFR files into memory at once for analysis. We should process these serially
-        // from the queue.
+        // from the queue. If we are getting overloaded then our response time to each subsequent
+        // request will continue to grow unbounded, so at some point we should stop accepting
+        // requests when the queue is too long.
         long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
         long start = System.nanoTime();
 

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -108,6 +108,9 @@ public class ReportResource {
     @POST
     public String getReportFromPresigned(RoutingContext ctx, @BeanParam PresignedFormData form)
             throws IOException, URISyntaxException {
+        // TODO queue these requests so we don't overload ourselves, in particular by reading
+        // multiple JFR files into memory at once for analysis. We should process these serially
+        // from the queue.
         long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
         long start = System.nanoTime();
 

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -15,10 +15,17 @@
  */
 package io.cryostat.reports;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -47,6 +54,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -66,9 +74,19 @@ public class ReportResource {
     @ConfigProperty(name = "io.cryostat.reports.timeout", defaultValue = "29000")
     String timeoutMs;
 
-    @Inject Logger logger;
+    @ConfigProperty(name = "cryostat.storage.base-uri")
+    Optional<String> storageBase;
+
+    @ConfigProperty(name = "cryostat.storage.auth-method")
+    Optional<String> storageAuthMethod;
+
+    @ConfigProperty(name = "cryostat.storage.auth")
+    Optional<String> storageAuth;
+
     @Inject InterruptibleReportGenerator generator;
     @Inject FileSystem fs;
+    @Inject ObjectMapper mapper;
+    @Inject Logger logger;
 
     RuleFilterParser rfp = new RuleFilterParser();
 
@@ -88,11 +106,70 @@ public class ReportResource {
     public void healthCheck() {}
 
     @Blocking
+    @Path("remote_report")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @POST
+    public String getReportFromPresigned(RoutingContext ctx, @BeanParam PresignedFormData form)
+            throws IOException, URISyntaxException {
+        try {
+            long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
+            long start = System.nanoTime();
+
+            var file = Files.createTempFile(null, null);
+
+            UriBuilder uriBuilder =
+                    UriBuilder.newInstance()
+                            .uri(new URI(storageBase.get()))
+                            .path(form.path)
+                            .replaceQuery(form.query);
+            URI downloadUri = uriBuilder.build();
+            logger.infov("Attempting to download presigned recording from {0}", downloadUri);
+            HttpURLConnection httpConn = (HttpURLConnection) downloadUri.toURL().openConnection();
+            httpConn.setRequestMethod("GET");
+            if (storageAuth.isPresent() && storageAuth.isPresent()) {
+                httpConn.setRequestProperty(
+                        "Authorization",
+                        String.format("%s %s", storageAuthMethod.get(), storageAuth.get()));
+            }
+            try (var stream = httpConn.getInputStream();
+                    var downloadChannel = Channels.newChannel(stream);
+                    var fos = new FileOutputStream(file.toFile());
+                    var fileChannel = fos.getChannel(); ) {
+                fileChannel.transferFrom(downloadChannel, 0, Long.MAX_VALUE);
+            } finally {
+                httpConn.disconnect();
+            }
+            long elapsed = System.nanoTime() - start;
+            logger.infov("Downloaded {0} in {1}", downloadUri, Duration.ofNanos(elapsed));
+
+            Predicate<IRule> predicate = rfp.parse(form.filter);
+            Future<Map<String, AnalysisResult>> evalMapFuture = null;
+
+            try (var stream = fs.newInputStream(file)) {
+                evalMapFuture = generator.generateEvalMapInterruptibly(stream, predicate);
+                ctxHelper(ctx, evalMapFuture);
+                return mapper.writeValueAsString(
+                        evalMapFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));
+            } catch (ExecutionException | InterruptedException e) {
+                throw new InternalServerErrorException(e);
+            } catch (TimeoutException e) {
+                throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
+            } finally {
+                cleanupHelper(evalMapFuture, file, file.toFile().getName(), start);
+            }
+        } catch (Exception e) {
+            logger.error(e);
+            throw e;
+        }
+    }
+
+    @Blocking
     @Path("report")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @POST
-    public String getEval(RoutingContext ctx, @BeanParam RecordingFormData form)
+    public String getReport(RoutingContext ctx, @BeanParam RecordingFormData form)
             throws IOException {
         FileUpload upload = form.file;
 
@@ -105,11 +182,10 @@ public class ReportResource {
         Predicate<IRule> predicate = rfp.parse(form.filter);
         Future<Map<String, AnalysisResult>> evalMapFuture = null;
 
-        ObjectMapper oMapper = new ObjectMapper();
         try (var stream = fs.newInputStream(file)) {
             evalMapFuture = generator.generateEvalMapInterruptibly(stream, predicate);
             ctxHelper(ctx, evalMapFuture);
-            return oMapper.writeValueAsString(
+            return mapper.writeValueAsString(
                     evalMapFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));
         } catch (ExecutionException | InterruptedException e) {
             throw new InternalServerErrorException(e);

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -113,6 +113,13 @@ public class ReportResource {
         // from the queue. If we are getting overloaded then our response time to each subsequent
         // request will continue to grow unbounded, so at some point we should stop accepting
         // requests when the queue is too long.
+        // Since this is a @Blocking method that runs on a worker thread pool, can we implement this
+        // serial queueing behaviour by simply synchronizing on a shared singleton resource ex. the
+        // generator instance?
+        // A better long-term solution would be to use a shared messaging queue between Cryostat and
+        // the report generators, so that Cryostat can put up a URL for a presigned recording to be
+        // processed and a free report generator can claim that work item and then post back the
+        // report response
         long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
         long start = System.nanoTime();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,7 @@ quarkus.http.body.delete-uploaded-files-on-end=true
 quarkus.native.additional-build-args =\
     -H:ResourceConfigurationFiles=resource-config.json,\
     -H:ReflectionConfigurationFiles=reflect-config.json
+
+cryostat.storage.base-uri=
+cryostat.storage.auth-method=
+cryostat.storage.auth=


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/pull/270

1. Whoever deploys the report generator can specify an object storage server base URI.
2. Instead of POSTing a whole JFR file, clients can instead POST a form containing a file path and query string. These are combined with the configuration storage server base URI to form a full absolute URI, which is expected to be a presigned URL for the object storage server. The report generator will issue a GET to this presigned URL to retrieve the JFR file on its own.
3. The report generator will then process the JFR file and respond in much the same way it normally would.

The storage server base URI is set as a configuration property to ensure that clients cannot request the report generator to send a request to an untrusted origin.

There are also configuration properties to allow the report generator to pass any additional authentication/authorization that may be in front of the object storage server. The object storage request itself should need only the presigned URL and its embedded token, but the object storage server may be deployed behind an auth proxy for example, so the report generator may need to know how to pass the auth proxy.

The advantage of this approach is that the full JFR file does not need to make an additional network hop, so there will be less overall traffic, less latency, and less chance of a throughput bottleneck. Disadvantages include the additional complexity of configuration, and potential security issues in case the remote object storage server can be made to redirect the report generator elsewhere or otherwise behave in unexpected ways.