### PR TITLE
ci(dependent-issues): update permissions

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -20,11 +20,16 @@ on:
 
 jobs:
   check:
+    permissions:
+      pull-requests: write
+      issues: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: z0al/dependent-issues@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          permissions: write
         with:
           # (Optional) Enable checking for dependencies in issues.
           # Enable by setting the value to "on". Default "off"


### PR DESCRIPTION
Update permissions for workflow to match https://github.com/cryostatio/cryostat3/blob/main/.github/workflows/dependent-issues.yml . Should resolve CI failure like https://github.com/cryostatio/cryostat-reports/actions/runs/7646699080/job/20836064591?pr=199 .
