### PR TITLE
ci(token): update token reference

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,12 +66,10 @@ jobs:
     - name: maven-settings
       uses: s4u/maven-settings-action@v2
       with:
-        servers: '[{"id": "github", "username": "dummy", "password": "${env.GITHUB_TOKEN_REF}"}]'
+        servers: '[{"id": "github", "username": "dummy", "password": "${ secrets.GITHUB_TOKEN }"}]'
         githubServer: false
     - name: Build application
       run: ./mvnw -Dquarkus.container-image.build=false -B -U clean verify
-      env:
-        GITHUB_TOKEN_REF: ${{ secrets.GH_PKGS_READ_TOKEN }}
     - name: Build container images and manifest
       id: buildah-build
       uses: redhat-actions/buildah-build@v2


### PR DESCRIPTION
Updates token used for GH Maven packages to the same configuration used in https://github.com/cryostatio/cryostat3/blob/5bd6653199ca79e23504aca8adfd2d7e7914885c/.github/workflows/push-ci.yaml#L66 . Hoping this fixes CI failures where `-core` cannot be downloaded.
