### PR TITLE
chore(jmc-core): update to JMC version 9.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,17 @@
   <version>2.5.0-SNAPSHOT</version>
   <repositories>
     <repository>
+      <id>s01.oss.sonatype.org-snapshot</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </repository>
+    <repository>
       <id>jmc-libs</id>
       <name>Adoptium JDK Mission Control Core Libraries</name>
       <url>https://adoptium.jfrog.io/artifactory/jmc-libs</url>
@@ -27,8 +38,7 @@
     <assembly-plugin.version>3.7.1</assembly-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.43.0</com.diffplug.spotless.maven.plugin.version>
     <org.codehaus.mojo.build.helper.plugin.version>3.5.0</org.codehaus.mojo.build.helper.plugin.version>
-    <!-- TODO: fix this once the jmc9 changes go into cyrostat-core -->
-    <io.cryostat.core.version>2.31.0-SNAPSHOT</io.cryostat.core.version>
+    <io.cryostat.core.version>3.0.0-SNAPSHOT</io.cryostat.core.version>
     <org.openjdk.jmc.version>9.0.0</org.openjdk.jmc.version>
     <com.mycila.license.maven.plugin.version>4.3</com.mycila.license.maven.plugin.version>
     <!-- TODO Remove if Quarkus updates Netty in 3.2 -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,14 @@
   <groupId>io.cryostat</groupId>
   <artifactId>cryostat-reports</artifactId>
   <version>2.5.0-SNAPSHOT</version>
+  <repositories>
+    <repository>
+      <id>jmc-libs</id>
+      <name>Adoptium JDK Mission Control Core Libraries</name>
+      <url>https://adoptium.jfrog.io/artifactory/jmc-libs</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
   <properties>
     <compiler-plugin.version>3.13.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -19,7 +27,9 @@
     <assembly-plugin.version>3.7.1</assembly-plugin.version>
     <com.diffplug.spotless.maven.plugin.version>2.43.0</com.diffplug.spotless.maven.plugin.version>
     <org.codehaus.mojo.build.helper.plugin.version>3.5.0</org.codehaus.mojo.build.helper.plugin.version>
-    <io.cryostat.core.version>2.30.3</io.cryostat.core.version>
+    <!-- TODO: fix this once the jmc9 changes go into cyrostat-core -->
+    <io.cryostat.core.version>2.31.0-SNAPSHOT</io.cryostat.core.version>
+    <org.openjdk.jmc.version>9.0.0</org.openjdk.jmc.version>
     <com.mycila.license.maven.plugin.version>4.3</com.mycila.license.maven.plugin.version>
     <!-- TODO Remove if Quarkus updates Netty in 3.2 -->
     <io.netty.version>4.1.108.Final</io.netty.version>
@@ -70,6 +80,26 @@
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmc</groupId>
+      <artifactId>common</artifactId>
+      <version>${org.openjdk.jmc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmc</groupId>
+      <artifactId>flightrecorder</artifactId>
+      <version>${org.openjdk.jmc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmc</groupId>
+      <artifactId>flightrecorder.rules</artifactId>
+      <version>${org.openjdk.jmc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmc</groupId>
+      <artifactId>flightrecorder.rules.jdk</artifactId>
+      <version>${org.openjdk.jmc.version}</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
This PR is a follow-up to the one in cryostat-core (https://github.com/cryostatio/cryostat-core/pull/362) to update JMC core dependencies to 9.0.0.

I've added the sonatype snapshot repository under the `<repositories>` in the pom, and set snapshots to enabled, releases to disabled, and set the update policy to always so that it always fetches the latest snapshot when building. This is following some documentation I found on the checkstyle wiki on how they use snapshot jars: https://github.com/checkstyle/checkstyle/wiki/How-to-use-Checkstyle-snapshot-artifacts
