### PR TITLE
build(cryostat3): bump version and publish weekly builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1' # every Monday at midnight
   push:
     branches:
       - main

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.cryostat</groupId>
   <artifactId>cryostat-reports</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <repositories>
     <repository>
       <id>s01.oss.sonatype.org-snapshot</id>


### PR DESCRIPTION
- chore(pom): bump version to 3.0.0-SNAPSHOT
- ci(cron): enable weekly cron build

See #233

Bumps version in preparation for upcoming release.

Adds a cron weekly CI build trigger. This is useful since the `cryostat-core` project now pushes snapshot builds and will not make mid-cycle releases of its own. The weekly builds ensure that `-core` changes get picked up and incorporated into `cryostat-reports` container images. There is also a manual workflow dispatch trigger added, in case there is some critical need to force a rebuild.
