### PR TITLE
fix(memory): disable memoryfactor 'feature' by default

### DIFF
--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -60,8 +60,8 @@ public class ReportResource {
     static final String SINGLETHREAD_PROPERTY =
             "org.openjdk.jmc.flightrecorder.parser.singlethreaded";
 
-    @ConfigProperty(name = "io.cryostat.reports.memory-factor", defaultValue = "10")
-    String memoryFactor;
+    @ConfigProperty(name = "io.cryostat.reports.memory-factor", defaultValue = "0")
+    long memoryFactor;
 
     @ConfigProperty(name = "io.cryostat.reports.timeout", defaultValue = "29000")
     String timeoutMs;
@@ -141,13 +141,7 @@ public class ReportResource {
                     TimeUnit.NANOSECONDS.toMillis(elapsed));
         }
 
-        Runtime runtime = Runtime.getRuntime();
-        System.gc();
-        long availableMemory = runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory();
-        long maxHandleableSize = availableMemory / Long.parseLong(memoryFactor);
-        if (file.toFile().length() > maxHandleableSize) {
-            throw new ClientErrorException(Response.Status.REQUEST_ENTITY_TOO_LARGE);
-        }
+        assertContentLength(file.toFile().length());
 
         now = System.nanoTime();
         elapsed = now - start;
@@ -155,6 +149,28 @@ public class ReportResource {
             throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT);
         }
         return Pair.of(file, Pair.of(start, elapsed));
+    }
+
+    private void assertContentLength(long length) {
+        if (memoryFactor <= 0) {
+            return;
+        }
+        if (length <= 0) {
+            logger.debugv("Request file has indeterminate length");
+            return;
+        }
+        logger.debugv("Request file has size {0} bytes", length);
+        Runtime runtime = Runtime.getRuntime();
+        System.gc();
+        long availableMemory = runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory();
+        long maxHandleableSize = availableMemory / memoryFactor;
+        if (length > maxHandleableSize) {
+            logger.warnv(
+                    "Rejecting request for file of {0} bytes. Estimated maximum handleable size is"
+                            + " {1} bytes.",
+                    length, maxHandleableSize);
+            throw new ClientErrorException(Response.Status.REQUEST_ENTITY_TOO_LARGE);
+        }
     }
 
     private void ctxHelper(RoutingContext ctx, Future<?> ff) {


### PR DESCRIPTION
See #200

Backports the change that disables the old and very rough heuristic about "memory factor" and maximum file size that the generator should attempt to handle.

The report generator is normally deployed as part of a Kubernetes Deployment which will handle cases where the JVM OOMs and dies by restarting the container, and Cryostat should gracefully handle these failures better now with the more recent long-running job API. So rather than applying this crude and overly conservative heuristic to try to preserve the report generator from dying, just let it make the attempt and use all available resources.

To test:
1. `export REPORTS_IMG=quay.io/andrewazores/cryostat-reports:disable-memoryfactor-1`, build and deploy Operator
2. Create Cryostat CR instance:
```yaml
  spec:
    reportOptions:
      replicas: 1
      resources:
        limits:
          memory: 192Mi
```
3. Wait for everything to come up.
4. Open Cryostat UI, go to Archives > Uploads, upload a large JFR file. I have a 150MiB sample file I can share. This is close to the container allocated memory and clearly beyond the `availableMemory / 10` default memory factor limit that was previously applied.
5. See that the container (most probably) OOMs, but Cryostat handles this gracefully with an error notification and OpenShift restarts the Pod. Try with a smaller recording and see that it succeeds.