### PR TITLE
feat(diagnostics): Add support for heap dump analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-container-image-docker</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/io/cryostat/reports/HeapDumpFormData.java
+++ b/src/main/java/io/cryostat/reports/HeapDumpFormData.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.reports;
+
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+public class HeapDumpFormData {
+    @RestForm
+    @PartType(MediaType.APPLICATION_OCTET_STREAM)
+    public FileUpload file;
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public String heapDumpId;
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public String jvmId;
+}

--- a/src/main/java/io/cryostat/reports/PresignedHeapDumpFormData.java
+++ b/src/main/java/io/cryostat/reports/PresignedHeapDumpFormData.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.reports;
+
+import java.net.URI;
+
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+
+public class PresignedHeapDumpFormData {
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public URI uri;
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public String heapDumpId;
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public String jvmId;
+}

--- a/src/main/java/io/cryostat/reports/Producers.java
+++ b/src/main/java/io/cryostat/reports/Producers.java
@@ -18,6 +18,7 @@ package io.cryostat.reports;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 
+import io.cryostat.core.diagnostic.InterruptibleHeapDumpReportGenerator;
 import io.cryostat.core.reports.InterruptibleReportGenerator;
 import io.cryostat.core.util.RuleFilterParser;
 import io.cryostat.libcryostat.sys.FileSystem;
@@ -38,6 +39,14 @@ public class Producers {
                         || Boolean.getBoolean(ReportResource.SINGLETHREAD_PROPERTY);
         return new InterruptibleReportGenerator(
                 singleThread ? Executors.newSingleThreadExecutor() : ForkJoinPool.commonPool());
+    }
+
+    @Produces
+    // RequestScoped so that each individual report generation request has its own interruptible
+    // generator with an independent task queueing thread which dispatches to the shared common pool
+    @RequestScoped
+    InterruptibleHeapDumpReportGenerator produceHeapDumpReportGenerator() {
+        return new InterruptibleHeapDumpReportGenerator();
     }
 
     @Produces

--- a/src/main/java/io/cryostat/reports/Producers.java
+++ b/src/main/java/io/cryostat/reports/Producers.java
@@ -49,7 +49,8 @@ public class Producers {
         boolean singleThread =
                 Runtime.getRuntime().availableProcessors() < 2
                         || Boolean.getBoolean(ReportResource.SINGLETHREAD_PROPERTY);
-        return new HeapDumpReportGenerator(singleThread ? Executors.newSingleThreadExecutor() : ForkJoinPool.commonPool());
+        return new HeapDumpReportGenerator(
+                singleThread ? Executors.newSingleThreadExecutor() : ForkJoinPool.commonPool());
     }
 
     @Produces

--- a/src/main/java/io/cryostat/reports/Producers.java
+++ b/src/main/java/io/cryostat/reports/Producers.java
@@ -18,7 +18,7 @@ package io.cryostat.reports;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 
-import io.cryostat.core.diagnostic.InterruptibleHeapDumpReportGenerator;
+import io.cryostat.core.diagnostic.HeapDumpReportGenerator;
 import io.cryostat.core.reports.InterruptibleReportGenerator;
 import io.cryostat.core.util.RuleFilterParser;
 import io.cryostat.libcryostat.sys.FileSystem;
@@ -45,8 +45,11 @@ public class Producers {
     // RequestScoped so that each individual report generation request has its own interruptible
     // generator with an independent task queueing thread which dispatches to the shared common pool
     @RequestScoped
-    InterruptibleHeapDumpReportGenerator produceHeapDumpReportGenerator() {
-        return new InterruptibleHeapDumpReportGenerator();
+    HeapDumpReportGenerator produceHeapDumpReportGenerator() {
+        boolean singleThread =
+                Runtime.getRuntime().availableProcessors() < 2
+                        || Boolean.getBoolean(ReportResource.SINGLETHREAD_PROPERTY);
+        return new HeapDumpReportGenerator(singleThread ? Executors.newSingleThreadExecutor() : ForkJoinPool.commonPool());
     }
 
     @Produces

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -43,6 +43,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
+import io.cryostat.core.diagnostic.HeapDumpAnalysis;
+import io.cryostat.core.diagnostic.InterruptibleHeapDumpReportGenerator;
 import io.cryostat.core.reports.InterruptibleReportGenerator;
 import io.cryostat.core.reports.InterruptibleReportGenerator.AnalysisResult;
 import io.cryostat.core.util.RuleFilterParser;
@@ -107,6 +109,7 @@ public class ReportResource {
     Optional<java.nio.file.Path> storageCertPath;
 
     @Inject InterruptibleReportGenerator generator;
+    @Inject InterruptibleHeapDumpReportGenerator heapDumpGenerator;
     @Inject RuleFilterParser rfp;
     @Inject FileSystem fs;
     @Inject ObjectMapper mapper;
@@ -252,6 +255,129 @@ public class ReportResource {
             throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
         } finally {
             cleanupHelper(evalMapFuture, file, upload.fileName(), start);
+        }
+    }
+
+
+    @Blocking
+    @Path("heapdump/remote_report")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @POST
+    public String getHeapDumpReportFromPresigned(RoutingContext ctx, @BeanParam PresignedHeapDumpFormData form)
+            throws IOException, URISyntaxException {
+        // TODO queue these requests so we don't overload ourselves, in particular by reading
+        // multiple Heap Dump files into memory at once for analysis. We should process these serially
+        // from the queue. If we are getting overloaded then our response time to each subsequent
+        // request will continue to grow unbounded, so at some point we should stop accepting
+        // requests when the queue is too long.
+        // Since this is a @Blocking method that runs on a worker thread pool, can we implement this
+        // serial queueing behaviour by simply synchronizing on a shared singleton resource ex. the
+        // generator instance?
+        // A better long-term solution would be to use a shared messaging queue between Cryostat and
+        // the report generators, so that Cryostat can put up a URL for a presigned recording to be
+        // processed and a free report generator can claim that work item and then post back the
+        // report response
+        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
+        long start = System.nanoTime();
+
+        logger.debugv("Attempting to download presigned heap dump from {0}", form.uri);
+        HttpURLConnection httpConn = (HttpURLConnection) form.uri.toURL().openConnection();
+        httpConn.setRequestMethod("GET");
+        if (httpConn instanceof HttpsURLConnection) {
+            HttpsURLConnection httpsConn = (HttpsURLConnection) httpConn;
+            if (storageTlsIgnore) {
+                try {
+                    httpsConn.setSSLSocketFactory(
+                            ignoreSslContext(storageTlsVersion).getSocketFactory());
+                } catch (Exception e) {
+                    logger.error(e);
+                    throw new InternalServerErrorException(e);
+                }
+            } else if (storageCaPath.isPresent() || storageCertPath.isPresent()) {
+                if (!(storageCaPath.isPresent() && storageCertPath.isPresent())) {
+                    Exception e =
+                            new IllegalStateException(
+                                    String.format(
+                                            "%s and %s must be both set or both unset",
+                                            "cryostat.storage.tls.ca.path",
+                                            "cryostat.storage.tls.cert.path"));
+                    logger.error(e);
+                    throw new InternalServerErrorException(e);
+                }
+                try {
+                    httpsConn.setSSLSocketFactory(
+                            trustSslCertContext(
+                                            storageTlsVersion,
+                                            storageCaPath.get(),
+                                            storageCertPath.get())
+                                    .getSocketFactory());
+                } catch (Exception e) {
+                    logger.error(e);
+                    throw new InternalServerErrorException(e);
+                }
+            }
+            if (!storageHostnameVerify) {
+                httpsConn.setHostnameVerifier((hostname, session) -> true);
+            }
+        }
+        if (storageAuthMethod.isPresent() && storageAuth.isPresent()) {
+            httpConn.setRequestProperty(
+                    "Authorization",
+                    String.format("%s %s", storageAuthMethod.get(), storageAuth.get()));
+        }
+
+        assertContentLength(httpConn.getContentLengthLong());
+        try (var stream = httpConn.getInputStream()) {
+            Future<HeapDumpAnalysis> evalFuture = null;
+
+            evalFuture = heapDumpGenerator.generateInterruptibly(form.jvmId, form.heapDumpId, stream);
+            long elapsed = System.nanoTime() - start;
+            ctxHelper(ctx, evalFuture);
+            return mapper.writeValueAsString(
+                    evalFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));
+        } catch (ExecutionException | InterruptedException e) {
+            logger.error(e);
+            throw new InternalServerErrorException(e);
+        } catch (TimeoutException e) {
+            logger.error(e);
+            throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
+        } catch (Exception e) {
+            logger.error(e);
+            throw e;
+        } finally {
+            httpConn.disconnect();
+        }
+    }
+
+    @Blocking
+    @Path("heapdump/report")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @POST
+    public String getHeapDumpReport(RoutingContext ctx, @BeanParam HeapDumpFormData form)
+            throws IOException {
+        FileUpload upload = form.file;
+
+        Pair<java.nio.file.Path, Pair<Long, Long>> uploadResult = handleUpload(upload);
+        java.nio.file.Path file = uploadResult.getLeft();
+        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
+        long start = uploadResult.getRight().getLeft();
+        long elapsed = uploadResult.getRight().getRight();
+
+        Future<HeapDumpAnalysis> evalFuture = null;
+
+        try (var stream = fs.newInputStream(file)) {
+            evalFuture = heapDumpGenerator.generateInterruptibly(form.jvmId, form.heapDumpId, stream);
+            ctxHelper(ctx, evalFuture);
+            return mapper.writeValueAsString(
+                    evalFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));
+        } catch (ExecutionException | InterruptedException e) {
+            throw new InternalServerErrorException(e);
+        } catch (TimeoutException e) {
+            throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
+        } finally {
+            cleanupHelper(evalFuture, file, upload.fileName(), start);
         }
     }
 

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -137,28 +136,14 @@ public class ReportResource {
     @Produces(MediaType.TEXT_PLAIN)
     public void healthCheck() {}
 
-    @Bulkhead
-    @Blocking
+    @Bulkhead(value = 1)
+    @Timeout(value = 29000, unit = ChronoUnit.MILLIS)
     @Path("remote_report")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @POST
     public String getReportFromPresigned(RoutingContext ctx, @BeanParam PresignedFormData form)
             throws IOException, URISyntaxException {
-        // TODO queue these requests so we don't overload ourselves, in particular by reading
-        // multiple JFR files into memory at once for analysis. We should process these serially
-        // from the queue. If we are getting overloaded then our response time to each subsequent
-        // request will continue to grow unbounded, so at some point we should stop accepting
-        // requests when the queue is too long.
-        // Since this is a @Blocking method that runs on a worker thread pool, can we implement this
-        // serial queueing behaviour by simply synchronizing on a shared singleton resource ex. the
-        // generator instance?
-        // A better long-term solution would be to use a shared messaging queue between Cryostat and
-        // the report generators, so that Cryostat can put up a URL for a presigned recording to be
-        // processed and a free report generator can claim that work item and then post back the
-        // report response
-        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
-        long start = System.nanoTime();
 
         logger.debugv("Attempting to download presigned recording from {0}", form.uri);
         HttpURLConnection httpConn = (HttpURLConnection) form.uri.toURL().openConnection();
@@ -168,16 +153,11 @@ public class ReportResource {
             Future<Map<String, AnalysisResult>> evalMapFuture = null;
 
             evalMapFuture = generator.generateEvalMapInterruptibly(stream, predicate);
-            long elapsed = System.nanoTime() - start;
             ctxHelper(ctx, evalMapFuture);
-            return mapper.writeValueAsString(
-                    evalMapFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));
+            return mapper.writeValueAsString(evalMapFuture.get());
         } catch (ExecutionException | InterruptedException e) {
             logger.error(e);
             throw new InternalServerErrorException(e);
-        } catch (TimeoutException e) {
-            logger.error(e);
-            throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
         } catch (Exception e) {
             logger.error(e);
             throw e;
@@ -187,7 +167,8 @@ public class ReportResource {
     }
 
     @Blocking
-    @Bulkhead
+    @Bulkhead(value = 1)
+    @Timeout(value = 29000, unit = ChronoUnit.MILLIS)
     @Path("report")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -198,9 +179,7 @@ public class ReportResource {
 
         Pair<java.nio.file.Path, Pair<Long, Long>> uploadResult = handleUpload(upload);
         java.nio.file.Path file = uploadResult.getLeft();
-        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
         long start = uploadResult.getRight().getLeft();
-        long elapsed = uploadResult.getRight().getRight();
 
         if (StringUtils.isNotBlank(form.filter)) {
             logger.debugv("Received request with filter: {0}", form.filter);
@@ -211,12 +190,9 @@ public class ReportResource {
         try (var stream = fs.newInputStream(file)) {
             evalMapFuture = generator.generateEvalMapInterruptibly(stream, predicate);
             ctxHelper(ctx, evalMapFuture);
-            return mapper.writeValueAsString(
-                    evalMapFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));
+            return mapper.writeValueAsString(evalMapFuture.get());
         } catch (ExecutionException | InterruptedException e) {
             throw new InternalServerErrorException(e);
-        } catch (TimeoutException e) {
-            throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
         } finally {
             cleanupHelper(evalMapFuture, file, upload.fileName(), start);
         }
@@ -299,7 +275,7 @@ public class ReportResource {
     }
 
     @Blocking
-    @Bulkhead
+    @Bulkhead(value = 1)
     @Timeout(value = 29000, unit = ChronoUnit.MILLIS)
     @Path("heapdump/report")
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -70,6 +70,7 @@ import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
 import org.openjdk.jmc.common.io.IOToolkit;
@@ -130,6 +131,7 @@ public class ReportResource {
     @Produces(MediaType.TEXT_PLAIN)
     public void healthCheck() {}
 
+    @Bulkhead
     @Blocking
     @Path("remote_report")
     @Produces(MediaType.APPLICATION_JSON)
@@ -154,52 +156,7 @@ public class ReportResource {
 
         logger.debugv("Attempting to download presigned recording from {0}", form.uri);
         HttpURLConnection httpConn = (HttpURLConnection) form.uri.toURL().openConnection();
-        httpConn.setRequestMethod("GET");
-        if (httpConn instanceof HttpsURLConnection) {
-            HttpsURLConnection httpsConn = (HttpsURLConnection) httpConn;
-            if (storageTlsIgnore) {
-                try {
-                    httpsConn.setSSLSocketFactory(
-                            ignoreSslContext(storageTlsVersion).getSocketFactory());
-                } catch (Exception e) {
-                    logger.error(e);
-                    throw new InternalServerErrorException(e);
-                }
-            } else if (storageCaPath.isPresent() || storageCertPath.isPresent()) {
-                if (!(storageCaPath.isPresent() && storageCertPath.isPresent())) {
-                    Exception e =
-                            new IllegalStateException(
-                                    String.format(
-                                            "%s and %s must be both set or both unset",
-                                            "cryostat.storage.tls.ca.path",
-                                            "cryostat.storage.tls.cert.path"));
-                    logger.error(e);
-                    throw new InternalServerErrorException(e);
-                }
-                try {
-                    httpsConn.setSSLSocketFactory(
-                            trustSslCertContext(
-                                            storageTlsVersion,
-                                            storageCaPath.get(),
-                                            storageCertPath.get())
-                                    .getSocketFactory());
-                } catch (Exception e) {
-                    logger.error(e);
-                    throw new InternalServerErrorException(e);
-                }
-            }
-            if (!storageHostnameVerify) {
-                httpsConn.setHostnameVerifier((hostname, session) -> true);
-            }
-        }
-        if (storageAuthMethod.isPresent() && storageAuth.isPresent()) {
-            httpConn.setRequestProperty(
-                    "Authorization",
-                    String.format("%s %s", storageAuthMethod.get(), storageAuth.get()));
-        }
-
-        assertContentLength(httpConn.getContentLengthLong());
-        try (var stream = httpConn.getInputStream()) {
+        try (var stream = getPresignedObjectStream(httpConn)) {
 
             Predicate<IRule> predicate = rfp.parse(form.filter);
             Future<Map<String, AnalysisResult>> evalMapFuture = null;
@@ -224,6 +181,7 @@ public class ReportResource {
     }
 
     @Blocking
+    @Bulkhead
     @Path("report")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -258,31 +216,7 @@ public class ReportResource {
         }
     }
 
-
-    @Blocking
-    @Path("heapdump/remote_report")
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    @POST
-    public String getHeapDumpReportFromPresigned(RoutingContext ctx, @BeanParam PresignedHeapDumpFormData form)
-            throws IOException, URISyntaxException {
-        // TODO queue these requests so we don't overload ourselves, in particular by reading
-        // multiple Heap Dump files into memory at once for analysis. We should process these serially
-        // from the queue. If we are getting overloaded then our response time to each subsequent
-        // request will continue to grow unbounded, so at some point we should stop accepting
-        // requests when the queue is too long.
-        // Since this is a @Blocking method that runs on a worker thread pool, can we implement this
-        // serial queueing behaviour by simply synchronizing on a shared singleton resource ex. the
-        // generator instance?
-        // A better long-term solution would be to use a shared messaging queue between Cryostat and
-        // the report generators, so that Cryostat can put up a URL for a presigned recording to be
-        // processed and a free report generator can claim that work item and then post back the
-        // report response
-        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
-        long start = System.nanoTime();
-
-        logger.debugv("Attempting to download presigned heap dump from {0}", form.uri);
-        HttpURLConnection httpConn = (HttpURLConnection) form.uri.toURL().openConnection();
+    private InputStream getPresignedObjectStream(HttpURLConnection httpConn) {
         httpConn.setRequestMethod("GET");
         if (httpConn instanceof HttpsURLConnection) {
             HttpsURLConnection httpsConn = (HttpsURLConnection) httpConn;
@@ -321,16 +255,41 @@ public class ReportResource {
                 httpsConn.setHostnameVerifier((hostname, session) -> true);
             }
         }
+        logger.debugv("Attempting to download presigned heap dump from {0}", form.uri);
         if (storageAuthMethod.isPresent() && storageAuth.isPresent()) {
             httpConn.setRequestProperty(
                     "Authorization",
                     String.format("%s %s", storageAuthMethod.get(), storageAuth.get()));
         }
-
         assertContentLength(httpConn.getContentLengthLong());
-        try (var stream = httpConn.getInputStream()) {
-            Future<HeapDumpAnalysis> evalFuture = null;
+        return httpConn.getInputStream();
+    }
 
+    @Blocking
+    @Bulkhead
+    @Path("heapdump/remote_report")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @POST
+    public String getHeapDumpReportFromPresigned(RoutingContext ctx, @BeanParam PresignedHeapDumpFormData form)
+            throws IOException, URISyntaxException {
+        // TODO queue these requests so we don't overload ourselves, in particular by reading
+        // multiple Heap Dump files into memory at once for analysis. We should process these serially
+        // from the queue. If we are getting overloaded then our response time to each subsequent
+        // request will continue to grow unbounded, so at some point we should stop accepting
+        // requests when the queue is too long.
+        // Since this is a @Blocking method that runs on a worker thread pool, can we implement this
+        // serial queueing behaviour by simply synchronizing on a shared singleton resource ex. the
+        // generator instance?
+        // A better long-term solution would be to use a shared messaging queue between Cryostat and
+        // the report generators, so that Cryostat can put up a URL for a presigned recording to be
+        // processed and a free report generator can claim that work item and then post back the
+        // report response
+        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
+        long start = System.nanoTime();
+        HttpURLConnection httpConn = (HttpURLConnection) form.uri.toURL().openConnection();
+        try (var stream = getPresignedObjectStream(httpConn)) {
+            Future<HeapDumpAnalysis> evalFuture = null;
             evalFuture = heapDumpGenerator.generateInterruptibly(form.jvmId, form.heapDumpId, stream);
             long elapsed = System.nanoTime() - start;
             ctxHelper(ctx, evalFuture);
@@ -351,6 +310,7 @@ public class ReportResource {
     }
 
     @Blocking
+    @Bulkhead
     @Path("heapdump/report")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -19,6 +19,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.ProtocolException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -44,7 +45,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 import io.cryostat.core.diagnostic.HeapDumpAnalysis;
-import io.cryostat.core.diagnostic.InterruptibleHeapDumpReportGenerator;
+import io.cryostat.core.diagnostic.HeapDumpReportGenerator;
 import io.cryostat.core.reports.InterruptibleReportGenerator;
 import io.cryostat.core.reports.InterruptibleReportGenerator.AnalysisResult;
 import io.cryostat.core.util.RuleFilterParser;
@@ -88,6 +89,9 @@ public class ReportResource {
     @ConfigProperty(name = "io.cryostat.reports.timeout", defaultValue = "29000")
     String timeoutMs;
 
+    @ConfigProperty(name = "io.cryostat.reports.heap-dump-memory-limit", defaultValue = "0")
+    int heapDumpMemoryLimit;
+
     @ConfigProperty(name = "cryostat.storage.auth-method")
     Optional<String> storageAuthMethod;
 
@@ -110,7 +114,7 @@ public class ReportResource {
     Optional<java.nio.file.Path> storageCertPath;
 
     @Inject InterruptibleReportGenerator generator;
-    @Inject InterruptibleHeapDumpReportGenerator heapDumpGenerator;
+    @Inject HeapDumpReportGenerator heapDumpGenerator;
     @Inject RuleFilterParser rfp;
     @Inject FileSystem fs;
     @Inject ObjectMapper mapper;
@@ -216,7 +220,7 @@ public class ReportResource {
         }
     }
 
-    private InputStream getPresignedObjectStream(HttpURLConnection httpConn) {
+    private InputStream getPresignedObjectStream(HttpURLConnection httpConn) throws IOException, ProtocolException {
         httpConn.setRequestMethod("GET");
         if (httpConn instanceof HttpsURLConnection) {
             HttpsURLConnection httpsConn = (HttpsURLConnection) httpConn;
@@ -255,7 +259,6 @@ public class ReportResource {
                 httpsConn.setHostnameVerifier((hostname, session) -> true);
             }
         }
-        logger.debugv("Attempting to download presigned heap dump from {0}", form.uri);
         if (storageAuthMethod.isPresent() && storageAuth.isPresent()) {
             httpConn.setRequestProperty(
                     "Authorization",
@@ -290,7 +293,7 @@ public class ReportResource {
         HttpURLConnection httpConn = (HttpURLConnection) form.uri.toURL().openConnection();
         try (var stream = getPresignedObjectStream(httpConn)) {
             Future<HeapDumpAnalysis> evalFuture = null;
-            evalFuture = heapDumpGenerator.generateInterruptibly(form.jvmId, form.heapDumpId, stream);
+            evalFuture = heapDumpGenerator.generate(stream, heapDumpMemoryLimit);
             long elapsed = System.nanoTime() - start;
             ctxHelper(ctx, evalFuture);
             return mapper.writeValueAsString(
@@ -328,7 +331,7 @@ public class ReportResource {
         Future<HeapDumpAnalysis> evalFuture = null;
 
         try (var stream = fs.newInputStream(file)) {
-            evalFuture = heapDumpGenerator.generateInterruptibly(form.jvmId, form.heapDumpId, stream);
+            evalFuture = heapDumpGenerator.generate(stream, heapDumpMemoryLimit);
             ctxHelper(ctx, evalFuture);
             return mapper.writeValueAsString(
                     evalFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -258,9 +258,12 @@ public class ReportResource {
             RoutingContext ctx, @BeanParam PresignedHeapDumpFormData form)
             throws IOException, URISyntaxException {
         HttpURLConnection httpConn = (HttpURLConnection) form.uri.toURL().openConnection();
+        java.nio.file.Path tmpFile = Files.createTempFile("", ".hprof");
         try (var stream = getPresignedObjectStream(httpConn)) {
+            // Copy the heap dump from storage to a temporary file for analysis
+            Files.copy(stream, tmpFile, StandardCopyOption.REPLACE_EXISTING);
             Future<HeapDumpAnalysis> evalFuture = null;
-            evalFuture = heapDumpGenerator.generate(stream, heapDumpMemoryLimit);
+            evalFuture = heapDumpGenerator.generate(tmpFile.toString(), heapDumpMemoryLimit);
             ctxHelper(ctx, evalFuture);
             return mapper.writeValueAsString(evalFuture.get());
         } catch (ExecutionException | InterruptedException e) {
@@ -271,6 +274,7 @@ public class ReportResource {
             throw e;
         } finally {
             httpConn.disconnect();
+            Files.deleteIfExists(tmpFile);
         }
     }
 
@@ -291,8 +295,8 @@ public class ReportResource {
 
         Future<HeapDumpAnalysis> evalFuture = null;
 
-        try (var stream = fs.newInputStream(file)) {
-            evalFuture = heapDumpGenerator.generate(stream, heapDumpMemoryLimit);
+        try {
+            evalFuture = heapDumpGenerator.generate(file.toString(), heapDumpMemoryLimit);
             ctxHelper(ctx, evalFuture);
             return mapper.writeValueAsString(evalFuture.get());
         } catch (ExecutionException | InterruptedException e) {

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -31,6 +31,7 @@ import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -72,6 +73,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
 import org.openjdk.jmc.common.io.IOToolkit;
@@ -220,7 +222,8 @@ public class ReportResource {
         }
     }
 
-    private InputStream getPresignedObjectStream(HttpURLConnection httpConn) throws IOException, ProtocolException {
+    private InputStream getPresignedObjectStream(HttpURLConnection httpConn)
+            throws IOException, ProtocolException {
         httpConn.setRequestMethod("GET");
         if (httpConn instanceof HttpsURLConnection) {
             HttpsURLConnection httpsConn = (HttpsURLConnection) httpConn;
@@ -269,41 +272,24 @@ public class ReportResource {
     }
 
     @Blocking
-    @Bulkhead
+    @Bulkhead(value = 1)
+    @Timeout(value = 29000, unit = ChronoUnit.MILLIS)
     @Path("heapdump/remote_report")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @POST
-    public String getHeapDumpReportFromPresigned(RoutingContext ctx, @BeanParam PresignedHeapDumpFormData form)
+    public String getHeapDumpReportFromPresigned(
+            RoutingContext ctx, @BeanParam PresignedHeapDumpFormData form)
             throws IOException, URISyntaxException {
-        // TODO queue these requests so we don't overload ourselves, in particular by reading
-        // multiple Heap Dump files into memory at once for analysis. We should process these serially
-        // from the queue. If we are getting overloaded then our response time to each subsequent
-        // request will continue to grow unbounded, so at some point we should stop accepting
-        // requests when the queue is too long.
-        // Since this is a @Blocking method that runs on a worker thread pool, can we implement this
-        // serial queueing behaviour by simply synchronizing on a shared singleton resource ex. the
-        // generator instance?
-        // A better long-term solution would be to use a shared messaging queue between Cryostat and
-        // the report generators, so that Cryostat can put up a URL for a presigned recording to be
-        // processed and a free report generator can claim that work item and then post back the
-        // report response
-        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
-        long start = System.nanoTime();
         HttpURLConnection httpConn = (HttpURLConnection) form.uri.toURL().openConnection();
         try (var stream = getPresignedObjectStream(httpConn)) {
             Future<HeapDumpAnalysis> evalFuture = null;
             evalFuture = heapDumpGenerator.generate(stream, heapDumpMemoryLimit);
-            long elapsed = System.nanoTime() - start;
             ctxHelper(ctx, evalFuture);
-            return mapper.writeValueAsString(
-                    evalFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));
+            return mapper.writeValueAsString(evalFuture.get());
         } catch (ExecutionException | InterruptedException e) {
             logger.error(e);
             throw new InternalServerErrorException(e);
-        } catch (TimeoutException e) {
-            logger.error(e);
-            throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
         } catch (Exception e) {
             logger.error(e);
             throw e;
@@ -314,6 +300,7 @@ public class ReportResource {
 
     @Blocking
     @Bulkhead
+    @Timeout(value = 29000, unit = ChronoUnit.MILLIS)
     @Path("heapdump/report")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -324,21 +311,16 @@ public class ReportResource {
 
         Pair<java.nio.file.Path, Pair<Long, Long>> uploadResult = handleUpload(upload);
         java.nio.file.Path file = uploadResult.getLeft();
-        long timeout = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(timeoutMs));
         long start = uploadResult.getRight().getLeft();
-        long elapsed = uploadResult.getRight().getRight();
 
         Future<HeapDumpAnalysis> evalFuture = null;
 
         try (var stream = fs.newInputStream(file)) {
             evalFuture = heapDumpGenerator.generate(stream, heapDumpMemoryLimit);
             ctxHelper(ctx, evalFuture);
-            return mapper.writeValueAsString(
-                    evalFuture.get(timeout - elapsed, TimeUnit.NANOSECONDS));
+            return mapper.writeValueAsString(evalFuture.get());
         } catch (ExecutionException | InterruptedException e) {
             throw new InternalServerErrorException(e);
-        } catch (TimeoutException e) {
-            throw new ServerErrorException(Response.Status.GATEWAY_TIMEOUT, e);
         } finally {
             cleanupHelper(evalFuture, file, upload.fileName(), start);
         }

--- a/src/main/java/io/cryostat/reports/ReportResource.java
+++ b/src/main/java/io/cryostat/reports/ReportResource.java
@@ -263,7 +263,7 @@ public class ReportResource {
             // Copy the heap dump from storage to a temporary file for analysis
             Files.copy(stream, tmpFile, StandardCopyOption.REPLACE_EXISTING);
             Future<HeapDumpAnalysis> evalFuture = null;
-            evalFuture = heapDumpGenerator.generate(tmpFile.toString(), heapDumpMemoryLimit);
+            evalFuture = heapDumpGenerator.generate(tmpFile, heapDumpMemoryLimit);
             ctxHelper(ctx, evalFuture);
             return mapper.writeValueAsString(evalFuture.get());
         } catch (ExecutionException | InterruptedException e) {
@@ -296,7 +296,7 @@ public class ReportResource {
         Future<HeapDumpAnalysis> evalFuture = null;
 
         try {
-            evalFuture = heapDumpGenerator.generate(file.toString(), heapDumpMemoryLimit);
+            evalFuture = heapDumpGenerator.generate(file, heapDumpMemoryLimit);
             ctxHelper(ctx, evalFuture);
             return mapper.writeValueAsString(evalFuture.get());
         } catch (ExecutionException | InterruptedException e) {


### PR DESCRIPTION
Related to: https://github.com/cryostatio/cryostat/issues/1127

Depends on https://github.com/cryostatio/cryostat-core/pull/666
Depends on cryostatio/cryostat-core#729

Adds support for generating heap dump analysis reports from cryostat-reports. Follows a similar strategy to how recording reports are generated and emitted.

Opening as draft pending any changes needed for frontend.